### PR TITLE
Suggesting some improvements

### DIFF
--- a/api/src/main/java/net/md_5/bungee/api/boss/BossBar.java
+++ b/api/src/main/java/net/md_5/bungee/api/boss/BossBar.java
@@ -13,32 +13,30 @@ public interface BossBar
     /**
      * Adds a player to view the boss bar. If the player is not connected or
      * the boss bar is not visible, it will not be sent.
-     * 
+     *
      * @param player the player you wish to see the boss bar
-     * @return success state
      */
-    boolean addPlayer(ProxiedPlayer player);
+    void addPlayer(ProxiedPlayer player);
 
     /**
-     * Adds all players to view the boss bar.
-     * 
+     * Adds all given players to view the boss bar.
+     *
      * @param players the players you wish to see the boss bar
-     * @see #addPlayer(ProxiedPlayer) 
+     * @see #addPlayer(ProxiedPlayer)
      */
     void addPlayers(Iterable<ProxiedPlayer> players);
 
     /**
-     * Removes the specified player from viewing the boss bar. If the player is not 
+     * Removes the specified player from viewing the boss bar. If the player is not
      * connected or the boss bar is not viewable the removal packet won't be sent.
-     * 
+     *
      * @param player the player you wish to remove from the boss bar
-     * @return success state
      */
-    boolean removePlayer(ProxiedPlayer player);
+    void removePlayer(ProxiedPlayer player);
 
     /**
      * Removes all specified players from viewing the boss bar.
-     * 
+     *
      * @param players the players you wish to remove from the boss bar
      * @see #removePlayer(ProxiedPlayer)
      */
@@ -114,7 +112,7 @@ public interface BossBar
     void setDivision(BossBarDivision division);
 
     /**
-     * Returns whenever the boss bar is visible. By default it will return <code>true</code>
+     * Returns whenever the boss bar is visible. By default the bossbar is not visible, and <code>false</code> is returned
      *
      * @return <code>true</code> if visible, <code>false</code> otherwise
      */
@@ -136,6 +134,14 @@ public interface BossBar
     Collection<BossBarFlag> getFlags();
 
     /**
+     * Adds a flag to the boss bar
+     *
+     * @param flag the flag you wish to add
+     * @return if the was was not present before
+     */
+    boolean addFlag(BossBarFlag flag);
+
+    /**
      * Adds flag(s) to the boss bar
      *
      * @param flags the flag(s) you wish to add
@@ -146,8 +152,9 @@ public interface BossBar
      * Removes flag from the boss bar
      *
      * @param flag the flag you wish to remove
+     * @return if the flag was present
      */
-    void removeFlag(BossBarFlag flag);
+    boolean removeFlag(BossBarFlag flag);
 
     /**
      * Removes flag(s) from the boss bar
@@ -156,4 +163,11 @@ public interface BossBar
      */
     void removeFlags(BossBarFlag... flags);
 
+    /**
+     * Returns whether the player's minecraft version is suited to see boss bars (Minecraft 1.9 or greater)
+     *
+     * @param player player to check
+     * @return whether the player can see boss bars
+     */
+    boolean canSeeBossbars(ProxiedPlayer player);
 }

--- a/api/src/main/java/net/md_5/bungee/api/boss/BossBarBuilder.java
+++ b/api/src/main/java/net/md_5/bungee/api/boss/BossBarBuilder.java
@@ -1,9 +1,13 @@
 package net.md_5.bungee.api.boss;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
 import com.google.common.base.Preconditions;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.WeakHashMap;
+import lombok.Getter;
+import lombok.experimental.Accessors;
 import net.md_5.bungee.api.ProxyServer;
 import net.md_5.bungee.api.chat.BaseComponent;
 import net.md_5.bungee.api.chat.ComponentBuilder;
@@ -12,6 +16,8 @@ import net.md_5.bungee.api.connection.ProxiedPlayer;
 /**
  * Represents a builder of {@link BossBar}
  */
+@Getter
+@Accessors(fluent = true)
 public final class BossBarBuilder
 {
 
@@ -19,7 +25,7 @@ public final class BossBarBuilder
     private BossBarColor color;
     private BossBarDivision division;
     private float health;
-    private Collection<ProxiedPlayer> players;
+    private Set<ProxiedPlayer> players;
     private BossBarFlag[] flags;
 
     /**
@@ -27,7 +33,22 @@ public final class BossBarBuilder
      */
     public BossBarBuilder()
     {
-        initDefault();
+        this( new ComponentBuilder( "Title not specified" ).create() );
+    }
+
+    /**
+     * Creates a boss bar builder with the specified title
+     *
+     * @param title the boss bar title you wish to create a boss bar builder with
+     */
+    public BossBarBuilder(BaseComponent[] title)
+    {
+        this.title(title);
+        color = BossBarColor.PINK;
+        division = BossBarDivision.SOLID;
+        health = 1.0f;
+        players = Collections.newSetFromMap( new WeakHashMap<ProxiedPlayer, Boolean>() );
+        flags = new BossBarFlag[ 0 ];
     }
 
     /**
@@ -38,17 +59,12 @@ public final class BossBarBuilder
      */
     public BossBarBuilder(BossBarBuilder original)
     {
-        initCopy( original );
-    }
-
-    /**
-     * Creates a boss bar builder with the specified title
-     *
-     * @param title the boss bar title you wish to create a boss bar builder with
-     */
-    public BossBarBuilder(BaseComponent[] title)
-    {
-        initTitle( title );
+        this.title = original.title;
+        this.color = original.color;
+        this.division = original.division;
+        this.health = original.health;
+        this.players = original.players;
+        this.flags = original.flags;
     }
 
     /**
@@ -59,8 +75,7 @@ public final class BossBarBuilder
      */
     public BossBarBuilder title(BaseComponent[] title)
     {
-        Preconditions.checkNotNull( title, "title" );
-        this.title = title;
+        this.title = Preconditions.checkNotNull( title, "title" );
         return this;
     }
 
@@ -72,7 +87,7 @@ public final class BossBarBuilder
      */
     public BossBarBuilder color(BossBarColor color)
     {
-        this.color = color;
+        this.color = Preconditions.checkNotNull( color, "color" );
         return this;
     }
 
@@ -84,7 +99,7 @@ public final class BossBarBuilder
      */
     public BossBarBuilder division(BossBarDivision division)
     {
-        this.division = division;
+        this.division = Preconditions.checkNotNull( division, "division" );
         return this;
     }
 
@@ -97,6 +112,7 @@ public final class BossBarBuilder
      */
     public BossBarBuilder health(float health)
     {
+        Preconditions.checkArgument( 0 <= health && health <= 1, "health may not be lower than 0 or greater than 1" );
         this.health = health;
         return this;
     }
@@ -135,6 +151,7 @@ public final class BossBarBuilder
      */
     public BossBarBuilder players(Iterable<ProxiedPlayer> players)
     {
+        Preconditions.checkNotNull( players, "players" );
         for ( ProxiedPlayer player : players )
         {
             player( player );
@@ -143,14 +160,14 @@ public final class BossBarBuilder
     }
 
     /**
-     * Adds the specified flag(s) to the boss bar.
+     * Sets the flag(s) of the boss bar.
      *
      * @param flags the flag(s) you wish to add
      * @return this BossBarBuilder for chaining
      */
     public BossBarBuilder flags(BossBarFlag... flags)
     {
-        this.flags = flags;
+        this.flags = Preconditions.checkNotNull( flags, "flags" );;
         return this;
     }
 
@@ -162,42 +179,14 @@ public final class BossBarBuilder
     public BossBar build()
     {
         BossBar bossBar = ProxyServer.getInstance().createBossBar( title, color, division, health );
-        if ( flags.length != 0 )
+        if ( flags.length > 0 )
         {
             bossBar.addFlags( flags );
         }
-        if ( players.size() != 0 )
+        if ( !players.isEmpty() )
         {
             bossBar.addPlayers( players );
         }
         return bossBar;
     }
-
-    //
-    private void initDefault()
-    {
-        this.title = new ComponentBuilder( "Title not specified" ).create();
-        color = BossBarColor.PINK;
-        division = BossBarDivision.SOLID;
-        health = 1.0f;
-        players = new ArrayList<>();
-        flags = new BossBarFlag[0];
-    }
-
-    private void initTitle(BaseComponent[] title)
-    {
-        initDefault();
-        this.title = title;
-    }
-
-    private void initCopy(BossBarBuilder builder)
-    {
-        this.title = builder.title;
-        this.color = builder.color;
-        this.division = builder.division;
-        this.health = builder.health;
-        this.players = builder.players;
-        this.flags = builder.flags;
-    }
-    //
 }

--- a/proxy/src/main/java/net/md_5/bungee/BungeeBossBar.java
+++ b/proxy/src/main/java/net/md_5/bungee/BungeeBossBar.java
@@ -43,6 +43,22 @@ public class BungeeBossBar implements net.md_5.bungee.api.boss.BossBar
     @ToString.Exclude
     private final UUID uuid = UUID.randomUUID();
 
+    @ToString.Exclude
+    private final BossBar addPacket = new BossBar( uuid, 0 );
+    @ToString.Exclude
+    private final BossBar removePacket = new BossBar( uuid, 1 );
+    @ToString.Exclude
+    private final BossBar healthUpdatePacket = new BossBar( uuid, 2 );
+    @ToString.Exclude
+    private final BossBar titleUpdatePacket = new BossBar( uuid, 3 );
+    @ToString.Exclude
+    private final BossBar styleUpdatePacket = new BossBar( uuid, 4 );
+    @ToString.Exclude
+    private final BossBar flagUpdatePacket = new BossBar( uuid, 5 );
+
+
+
+
     public BungeeBossBar(BaseComponent[] title, BossBarColor color, BossBarDivision division, float health)
     {
         setTitle( title );
@@ -57,7 +73,7 @@ public class BungeeBossBar implements net.md_5.bungee.api.boss.BossBar
         Preconditions.checkNotNull( player, "player" );
         if ( players.add( player ) && visible ) // order is important
         {
-            sendPacket( player, createAddPacket() );
+            sendPacket( player, addPacket() );
         }
     }
 
@@ -77,7 +93,7 @@ public class BungeeBossBar implements net.md_5.bungee.api.boss.BossBar
         Preconditions.checkNotNull( player, "player" );
         if ( players.remove( player ) && visible ) // order is important
         {
-            sendPacket( player, createRemovePacket() );
+            sendPacket( player, removePacket() );
         }
     }
 
@@ -94,7 +110,7 @@ public class BungeeBossBar implements net.md_5.bungee.api.boss.BossBar
     @Override
     public void removeAllPlayers()
     {
-        sendToAffected( createRemovePacket() );
+        sendToAffected( removePacket() );
         players.clear();
     }
 
@@ -110,7 +126,7 @@ public class BungeeBossBar implements net.md_5.bungee.api.boss.BossBar
         this.title = Preconditions.checkNotNull( title, "title" );
         if ( visible )
         {
-            sendToAffected( createTitleUpdatePacket() );
+            sendToAffected( titleUpdatePacket() );
         }
     }
 
@@ -122,7 +138,7 @@ public class BungeeBossBar implements net.md_5.bungee.api.boss.BossBar
         this.health = health;
         if ( prevHealth != health && visible )
         {
-            sendToAffected( createHealthUpdatePacket() );
+            sendToAffected( healthUpdatePacket() );
         }
     }
 
@@ -133,7 +149,7 @@ public class BungeeBossBar implements net.md_5.bungee.api.boss.BossBar
         this.color = Preconditions.checkNotNull( color, "color" );
         if ( prevColor != color && visible )
         {
-            sendToAffected( createStyleUpdatePacket() );
+            sendToAffected( styleUpdatePacket() );
         }
     }
 
@@ -144,7 +160,7 @@ public class BungeeBossBar implements net.md_5.bungee.api.boss.BossBar
         this.division = Preconditions.checkNotNull( division, "division" );
         if ( prevDivision != division && visible )
         {
-            sendToAffected( createStyleUpdatePacket() );
+            sendToAffected( styleUpdatePacket() );
         }
     }
 
@@ -154,10 +170,10 @@ public class BungeeBossBar implements net.md_5.bungee.api.boss.BossBar
         boolean previous = this.visible;
         if ( previous && !visible )
         {
-            sendToAffected( createRemovePacket() );
+            sendToAffected( removePacket() );
         } else if ( !previous && visible )
         {
-            sendToAffected( createAddPacket() );
+            sendToAffected( addPacket() );
         }
         this.visible = visible;
     }
@@ -175,7 +191,7 @@ public class BungeeBossBar implements net.md_5.bungee.api.boss.BossBar
         {
             if ( visible )
             {
-                sendToAffected( createFlagUpdatePacket() );
+                sendToAffected( flagUpdatePacket() );
             }
             return true;
         }
@@ -187,7 +203,7 @@ public class BungeeBossBar implements net.md_5.bungee.api.boss.BossBar
     {
         if ( this.flags.addAll( Arrays.asList( flags ) ) && visible )
         {
-            sendToAffected( createFlagUpdatePacket() );
+            sendToAffected( flagUpdatePacket() );
         }
     }
 
@@ -198,7 +214,7 @@ public class BungeeBossBar implements net.md_5.bungee.api.boss.BossBar
         {
             if ( this.visible )
             {
-                sendToAffected( createFlagUpdatePacket() );
+                sendToAffected( flagUpdatePacket() );
             }
             return true;
         }
@@ -210,7 +226,7 @@ public class BungeeBossBar implements net.md_5.bungee.api.boss.BossBar
     {
         if ( this.flags.removeAll( Arrays.asList( flags ) ) && visible )
         {
-            sendToAffected( createFlagUpdatePacket() );
+            sendToAffected( flagUpdatePacket() );
         }
     }
 
@@ -238,49 +254,44 @@ public class BungeeBossBar implements net.md_5.bungee.api.boss.BossBar
         return flagMask;
     }
 
-    private BossBar createAddPacket()
+    private BossBar addPacket()
     {
-        BossBar packet = new BossBar( uuid, 0 );
-        packet.setTitle( ComponentSerializer.toString( title ) );
-        packet.setColor( color.ordinal() );
-        packet.setDivision( division.ordinal() );
-        packet.setHealth( health );
-        packet.setFlags( serializeFlags() );
-        return packet;
+        addPacket.setTitle( ComponentSerializer.toString( title ) );
+        addPacket.setColor( color.ordinal() );
+        addPacket.setDivision( division.ordinal() );
+        addPacket.setHealth( health );
+        addPacket.setFlags( serializeFlags() );
+        return addPacket;
     }
 
-    private BossBar createRemovePacket()
+    private BossBar removePacket()
     {
-        return new BossBar( uuid, 1 );
+        return removePacket;
     }
 
-    private BossBar createHealthUpdatePacket()
+    private BossBar healthUpdatePacket()
     {
-        BossBar packet = new BossBar( uuid, 2 );
-        packet.setHealth( this.health );
-        return packet;
+        healthUpdatePacket.setHealth( health );
+        return healthUpdatePacket;
     }
 
-    private BossBar createTitleUpdatePacket()
+    private BossBar titleUpdatePacket()
     {
-        BossBar packet = new BossBar( uuid, 3 );
-        packet.setTitle( ComponentSerializer.toString( this.title ) );
-        return packet;
+        titleUpdatePacket.setTitle( ComponentSerializer.toString( title ) );
+        return titleUpdatePacket;
     }
 
-    private BossBar createStyleUpdatePacket()
+    private BossBar styleUpdatePacket()
     {
-        BossBar packet = new BossBar( uuid, 4 );
-        packet.setColor( color.ordinal() );
-        packet.setDivision( division.ordinal() );
-        return packet;
+        styleUpdatePacket.setColor( color.ordinal() );
+        styleUpdatePacket.setDivision( division.ordinal() );
+        return styleUpdatePacket;
     }
 
-    private BossBar createFlagUpdatePacket()
+    private BossBar flagUpdatePacket()
     {
-        BossBar packet = new BossBar( uuid, 5 );
-        packet.setFlags( serializeFlags() );
-        return packet;
+        flagUpdatePacket.setFlags( serializeFlags() );
+        return flagUpdatePacket;
     }
 
     /**


### PR DESCRIPTION
Interface:
- Remove boolean return on addPlayer/removePlayer because conditions are many
- Add method canSeeBossbars(ProxiedPlayer) to BossBar interface as replacement because it is more obvious what the reason is
- Set visibility to false by default (developers can do multiple addPlayers, then set visible and only one packet object has to be created
- Add addFlag method for one flag to add
- Add boolean return to add/remove flag methods because its easy (not sure if necessary)

Builder:
- Don't use separate private methods to initialise fields of BossBarBuilder
- Add a couple more null checks and health check to BossBarBuilder
- Replace list of players with a Set view of a WeakHashMap

Implementation:
- Set visible to false as default
- Replace list of players with a Set view of a WeakHashMap
- Initialise fields not dependant on constructor arguments before constructor
- Use setters in constructor to not have duplicate checking code
- Simple optimization in removeAllPlayers
- Outsource all packet creations into own methods
- Add "actually changed" checks to set methods of health, color and division before packet sending
- Move connected check to sendPacket method, because it should usually always return true (so useless pakcet object creations are not a performance problem) and makes the code cleaner
- Don't send multiple AddPackets to players who are added multiple times